### PR TITLE
Better redirect for __bma_error() and __bma_usage()

### DIFF
--- a/lib/shared.inc
+++ b/lib/shared.inc
@@ -5,7 +5,7 @@
 source $(dirname ${BASH_SOURCE[0]})/parameter.inc
 
 __bma_error() {
-  echo "ERROR: $@" > /dev/stderr
+  echo "ERROR: $@" >&2
   BMA_STATUS=1
   # TODO: Return zero. Returning non-zero should only happen when there is a
   # failure to return an error.
@@ -13,7 +13,7 @@ __bma_error() {
 }
 
 __bma_usage() {
-  echo "USAGE: ${FUNCNAME[1]} $@" > /dev/stderr
+  echo "USAGE: ${FUNCNAME[1]} $@" >&2
 }
 
 ## vim: ft=sh


### PR DESCRIPTION
Redirecting to /dev/stderr mostly doesn't work when you've used su to get in to an account in linux. People can argue about whether that's a bash/udev bug, but the behavior is there nonetheless.

See the long discussion here: https://unix.stackexchange.com/questions/38538/bash-dev-stderr-permission-denied